### PR TITLE
update licence to reflect the licencing of components submodule

### DIFF
--- a/io.github.zen_browser.zen.metainfo.xml
+++ b/io.github.zen_browser.zen.metainfo.xml
@@ -11,7 +11,7 @@
     <summary>A fast, beautifull browser</summary>
 
     <metadata_license>MIT</metadata_license>
-    <project_license>MPL-2.0</project_license>
+    <project_license>MPL-2.0 AND CC-BY-NC-ND-4.0</project_license>
 
     <description>
         <p>Zen Browser is a firefox based browser that will change the way you surf the web!</p>


### PR DESCRIPTION
The [components](https://github.com/zen-browser/components) repo is licenced under CC-BY-NC-ND-4.0, and is include as part of Zen browser. The flatpak metadata should be updated to reflect this.