### PR TITLE
Reorganize and improve metainfo

### DIFF
--- a/io.github.zen_browser.zen.metainfo.xml
+++ b/io.github.zen_browser.zen.metainfo.xml
@@ -1,30 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
+    <metadata_license>MIT</metadata_license>
+    <project_license>MPL-2.0</project_license>
     <id>io.github.zen_browser.zen</id>
-    <url type="homepage">https://get-zen.vercel.app</url>
-    <content_rating type="oars-1.1" />
+    
+    <name>Zen</name>
+    <summary>Your browser, your way</summary>
+    
     <developer id="io.github.zen_browser.zen">
         <name>Zen Team</name>
     </developer>
 
-    <name>Zen Browser</name>
-    <summary>A fast, beautifull browser</summary>
-
-    <metadata_license>MIT</metadata_license>
-    <project_license>MPL-2.0</project_license>
-
     <description>
-        <p>Zen Browser is a firefox based browser that will change the way you surf the web!</p>
-
+        <p>Zen is the best way to browse the web. Beautifully designed, privacy-focused, and packed with features. We care about your experience, not your data.</p>
         <ul>
-            <li>Split views</li>
-            <li>Web Sidebar</li>
-            <li>Tab Groups</li>
-            <li>Customizable UI</li>
+            <li>Split view</li>
+            <li>Web sidebar</li>
+            <li>Tab groups</li>
+            <li>Customizable interface</li>
             <li>Vertical Tabs</li>
             <li>And more...</li>
         </ul>
     </description>
+
+    <url type="homepage">https://zen-browser.app</url>
+    <url type="bugtracker">https://github.com/zen-browser/desktop/issues</url>
+    <url type="help">https://docs.zen-browser.app</url>
+    <url type="faq">https://docs.zen-browser.app/faq</url>
+    <url type="donation">https://www.patreon.com/zen_browser</url>
+    <url type="translate">https://crowdin.com/project/zen-browser</url>
+    <url type="contact">https://discord.gg/nnShMQzR4b</url>
+    <url type="vcs-browser">https://github.com/zen-browser</url>
+    <url type="contribute">https://docs.zen-browser.app/contribute/CONTRIBUTING</url>
+
+    <branding>
+        <color type="primary" scheme_preference="light">#d9d9d9</color>
+        <color type="primary" scheme_preference="dark">#f5f5f5</color>
+    </branding>
+    
+    <screenshots>
+        <screenshot type="default">
+            <image>https://get-zen.vercel.app/browser-dark.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://get-zen.vercel.app/browser-light.png</image>
+        </screenshot>
+    </screenshots>
+
+    <content_rating type="oars-1.1" />
+    <launchable type="desktop-id">io.github.zen_browser.zen.desktop</launchable>
+
+    <requires>
+        <display_length compare="ge">450</display_length>
+    </requires>
+
+    <recommends>
+        <internet>always</internet>
+    </recommends>
+
+    <supports>
+        <control>pointing</control>
+        <control>keyboard</control>
+    </supports>
 
     <releases>
         <release version="1.0.0-a.32" date="2024-08-22">
@@ -43,19 +80,4 @@
             <url type="details">https://get-zen.vercel.app/release-notes/1.0.0-a.8</url>
         </release>
     </releases>
-
-    <launchable type="desktop-id">io.github.zen_browser.zen.desktop</launchable>
-    <screenshots>
-        <screenshot type="default">
-            <image>https://get-zen.vercel.app/browser-dark.png</image>
-        </screenshot>
-        <screenshot>
-            <image>https://get-zen.vercel.app/browser-light.png</image>
-        </screenshot>
-    </screenshots>
-
-    <branding>
-        <color type="primary" scheme_preference="light">#d9d9d9</color>
-        <color type="primary" scheme_preference="dark">#f5f5f5</color>
-    </branding>
 </component>


### PR DESCRIPTION
Updates the metainfo to make the app integrate better with Linux app store frontends, and bring it more in line with Flathub's [metainfo quality guidelines](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines).

I've pulled in some text from the website for the description, populated the URL section with [relevant links](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url), and added info about screen size / input requirements.

I think the only thing missing for the app to be eligible for promotion on Flathub after this, is screenshots with shadows taken on Linux.

Let me know if anything with this should be changed.