### PR TITLE
Temporary fix for Release order in metadata.xml

### DIFF
--- a/io.github.zen_browser.zen.metainfo.xml
+++ b/io.github.zen_browser.zen.metainfo.xml
@@ -41,14 +41,14 @@
     <color type="primary" scheme_preference="dark">#f5f5f5</color>
   </branding>
   <releases>
-    <release version="1.0.0-a.32" date="01/09/2024">
-      <url type="details">https://zen-browser.app/release-notes/1.0.0-a.32</url>
+    <release version="1.0.0-a.35" date="03/09/2024">
+      <url type="details">https://zen-browser.app/release-notes/1.0.0-a.35</url>
     </release>
     <release version="1.0.0-a.34" date="01/09/2024">
       <url type="details">https://zen-browser.app/release-notes/1.0.0-a.34</url>
     </release>
-    <release version="1.0.0-a.35" date="03/09/2024">
-      <url type="details">https://zen-browser.app/release-notes/1.0.0-a.35</url>
+    <release version="1.0.0-a.32" date="01/09/2024">
+      <url type="details">https://zen-browser.app/release-notes/1.0.0-a.32</url>
     </release>
   </releases>
 </component>

--- a/io.github.zen_browser.zen.metainfo.xml
+++ b/io.github.zen_browser.zen.metainfo.xml
@@ -41,13 +41,13 @@
     <color type="primary" scheme_preference="dark">#f5f5f5</color>
   </branding>
   <releases>
-    <release version="1.0.0-a.35" date="03/09/2024">
+    <release version="1.0.0-a.35" date="2024-09-03">
       <url type="details">https://zen-browser.app/release-notes/1.0.0-a.35</url>
     </release>
-    <release version="1.0.0-a.34" date="01/09/2024">
+    <release version="1.0.0-a.34" date="2024-09-01">
       <url type="details">https://zen-browser.app/release-notes/1.0.0-a.34</url>
     </release>
-    <release version="1.0.0-a.32" date="01/09/2024">
+    <release version="1.0.0-a.32" date="2024-09-01">
       <url type="details">https://zen-browser.app/release-notes/1.0.0-a.32</url>
     </release>
   </releases>


### PR DESCRIPTION
Looking at the failing build https://buildbot.flathub.org/#/builders/25/builds/17850 we can see that FlatPak (for some stupid reason) requires the Releases to be in descending order.  This is a temporary fix to get the current release build and published onto FlatHub, as the Flatpak is currently stuck at a.32.

Also, the dates have to be in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
> THIS IS ONLY TEMPORARY, AND THE GITHUB ACTIONS WORKFLOW WHICH UPDATES THE RELEASES SECTION HAS TO BE FIXED TO FOLLOW THE REQUIRED ORDERING!