### PR TITLE
Add padding to icon for visual balance

### DIFF
--- a/icons/app.zen_browser.zen.svg
+++ b/icons/app.zen_browser.zen.svg
@@ -1,4 +1,4 @@
-<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="1024" height="1024" viewBox="-96 -96 1216 1216" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0_97_150)">
 <rect width="1024" height="1024" rx="185" fill="#202020"/>
 <circle cx="512.523" cy="512.523" r="134.573" stroke="#F2F0E3" stroke-width="30"/>


### PR DESCRIPTION
[Flathub guidelines](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines/#app-icon) suggest that app icons should have padding to help them fit with other app icons.

There's also [an issue on the main repo](https://github.com/zen-browser/desktop/issues/5106
) discussing this change.

In this pull request, I simply change the `viewBox` of the svg from `"0 0 1024 1024"` to `"-96 -96 1216 1216"`, to follow these guidelines.