### PR TITLE
Fix typo in README: "packges" corrected to "packages"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # flatpak
-📦 official flatpak packges for @zen-browser!
+📦 official flatpak packages for @zen-browser!


### PR DESCRIPTION
This PR fixes a minor spelling mistake in the README file where "packges" was written instead of "packages". No functional changes were made.